### PR TITLE
feat: hook up supabase persistence to zustand state/expo router

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,8 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "expo-secure-store"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "@supabase/supabase-js": "^2.38.4",
         "expo": "^51.0.38",
         "expo-constants": "~16.0.1",
+        "expo-crypto": "~13.0.2",
         "expo-dev-client": "~4.0.28",
         "expo-linking": "~6.3.1",
         "expo-router": "~3.5.14",
+        "expo-secure-store": "~13.0.2",
         "expo-status-bar": "~1.12.1",
         "expo-system-ui": "~3.0.4",
         "expo-web-browser": "~13.0.3",
@@ -10893,6 +10895,18 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-crypto": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-13.0.2.tgz",
+      "integrity": "sha512-7f/IMPYJZkBM21LNEMXGrNo/0uXSVfZTwufUdpNKedJR0fm5fH4DCSN79ZddlV26nF90PuXjK2inIbI6lb0qRA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-dev-client": {
       "version": "4.0.28",
       "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-4.0.28.tgz",
@@ -11221,6 +11235,15 @@
         "react-native-reanimated": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-13.0.2.tgz",
+      "integrity": "sha512-3QYgoneo8p8yeeBPBiAfokNNc2xq6+n8+Ob4fAlErEcf4H7Y72LH+K/dx0nQyWau2ZKZUXBxyyfuHFyVKrEVLg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "react-native-svg": "15.2.0",
     "react-native-svg-transformer": "^1.5.0",
     "react-native-web": "~0.19.10",
-    "zustand": "^5.0.1"
+    "zustand": "^5.0.1",
+    "expo-secure-store": "~13.0.2",
+    "expo-crypto": "~13.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/app/(auth)/index.tsx
+++ b/src/app/(auth)/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { supabase } from '@/utils/supabase';
 import { Text, StyleSheet, View, SafeAreaView, Alert, Button, TextInput } from 'react-native';
 import { useAuthStore } from '@store/useAuthStore';
-import { useRouter } from 'expo-router';
+import { Redirect, useRouter } from 'expo-router';
 
 export default function signInScreen() {
   const router = useRouter();
@@ -11,6 +11,10 @@ export default function signInScreen() {
   const [error, setError] = useState(null);
   const { signIn, signUp, isAuthenticated } = useAuthStore();
   console.log('🚀 ~ signInScreen ~ isAuthenticated:', isAuthenticated);
+
+  if (isAuthenticated) {
+    return <Redirect href="/(app)/(play)" />;
+  }
 
   const handlesignIn = async () => {
     try {

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,7 +1,9 @@
 import '../../global.css';
 import { Stack } from 'expo-router';
-
+import { useAuthListener } from '@/store/useAuthStore';
 export default function RootLayout() {
+  useAuthListener();
+  
   return (
     <Stack>
       <Stack.Screen name="(app)" options={{ headerShown: false, animation: 'fade' }} />

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -62,22 +62,20 @@ export const useAuthStore = create<AuthState & AuthActions>((set) => ({
 
 export const useAuthListener = () => {
   const updateIsAuthenticated = useAuthStore((state) => state.updateIsAuthenticated);
-  console.log('useAuthListener');
   useEffect(() => {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
-      console.log('onAuthStateChange', event, session);
       switch (event) {
         case 'SIGNED_OUT':
           updateIsAuthenticated(false);
           break;
         case 'INITIAL_SESSION':
-          updateIsAuthenticated(true);
-          break;
         case 'SIGNED_IN':
         case 'TOKEN_REFRESHED':
-          updateIsAuthenticated(true);
+          if (session?.access_token) {
+            updateIsAuthenticated(true);
+          }
           break;
         default:
         // no-op

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,8 +1,31 @@
-import { MMKV } from 'react-native-mmkv';
+import { MMKV } from "react-native-mmkv"
+import * as SecureStore from "expo-secure-store"
+import * as Crypto from "expo-crypto"
 
-export const storage = new MMKV({
-  id: 'session',
-});
+const fetchOrGenerateEncryptionKey = (): string => {
+  const encryptionKey = SecureStore.getItem("session-encryption-key")
+
+  if (encryptionKey) {
+    return encryptionKey
+  } else {
+    const uuid = Crypto.randomUUID()
+    SecureStore.setItem("session-encryption-key", uuid)
+    return uuid
+  }
+}
+
+const storage = new MMKV({
+  id: "session",
+  encryptionKey: fetchOrGenerateEncryptionKey(),
+})
+
+// TODO: Remove this workaround for encryption: https://github.com/mrousavy/react-native-mmkv/issues/665
+storage.set("workaround", true)
+
+/**
+ * A simple wrapper around MMKV that provides a base API
+ * that matches AsyncStorage for use with Supabase.
+ */
 
 /**
  * Get an item from storage by key
@@ -12,10 +35,10 @@ export const storage = new MMKV({
  */
 export async function getItem(key: string): Promise<string | null> {
   try {
-    return storage.getString(key) ?? null;
+    return storage.getString(key) ?? null
   } catch {
-    console.warn(`Failed to get key "${key}" from secure storage`);
-    return null;
+    console.warn(`Failed to get key "${key}" from secure storage`)
+    return null
   }
 }
 
@@ -27,9 +50,10 @@ export async function getItem(key: string): Promise<string | null> {
  */
 export async function setItem(key: string, value: string): Promise<void> {
   try {
-    storage.set(key, value);
+    console.log("setItem", { key, value })
+    storage.set(key, value)
   } catch {
-    console.warn(`Failed to set key "${key}" in secure storage`);
+    console.warn(`Failed to set key "${key}" in secure storage`)
   }
 }
 
@@ -40,8 +64,8 @@ export async function setItem(key: string, value: string): Promise<void> {
  */
 export async function removeItem(key: string): Promise<void> {
   try {
-    storage.delete(key);
+    storage.delete(key)
   } catch {
-    console.warn(`Failed to remove key "${key}" from secure storage`);
+    console.warn(`Failed to remove key "${key}" from secure storage`)
   }
 }


### PR DESCRIPTION
This PR: 

1. [Encrypts the user session](https://ignitecookbook.com/docs/recipes/Authentication/#encrypting-the-user-session)
2. Hooks up the Zustand store to set `isAuthenticated` based on the [Supabase auth listener](https://ignitecookbook.com/docs/recipes/Authentication/#listening-for-session-changes)
3. Sets up a redirect in the sign in page when `isAuthenticated` is true to go to `/(app)/(play)`

I added a few Expo dependencies for the encryption, so you'll want to run `npm install` and then rebuild natively (I used `npm run ios` here, but of course if you're using EAS you might do something differently.

Here's everything running. I've got my own Supabase environment variables for a test instance running here, but it should work fine with yours as long as your Supabase is configured:



https://github.com/user-attachments/assets/02f312e0-f702-4076-9fbb-14c1ac28146d

